### PR TITLE
Adjust the wrapper according to the window width

### DIFF
--- a/src/UI Macros/snd_xplore_main.html
+++ b/src/UI Macros/snd_xplore_main.html
@@ -808,6 +808,15 @@
               var snd_xplore_default_settings = JSON.parse("${JS:JSON.stringify(default_settings)}");
             </script>
 
+			<!-- Adjust the "top" attribute of the "wrapper" div accordingly to the header -->
+			<script type="text/javascript">
+				function resizeWrapper() {
+					document.getElementById("wrapper").style.top = document.getElementById("navbar").parentElement.offsetHeight + "px";
+				}
+				window.addEventListener("resize", resizeWrapper);
+				window.addEventListener("load", resizeWrapper);
+			</script>
+			
           </div>
         </div>
       </div>


### PR DESCRIPTION
If the width of the window is too small, the height of the navbar grows and some lines of the "wrapper" div are hidden (and some buttons from the left menu too). 

I have added an event listener to update the "top" attribute of the wrapper to match with the height of the navbar. 